### PR TITLE
Fix directory that the builder pulls from for uploading the artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,4 +54,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.platform }}-build
-        path: Build/${{ matrix.platform }}
+        path: Builds/${{ matrix.platform }}


### PR DESCRIPTION
I had a typo [in my last PR](https://github.com/JohnStegmaier/Pizza-Launch/pull/16) that prevented the script from uploading the compiled artifact to Github